### PR TITLE
Default terms adjusted + more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # 📋 Changelog for "LOOPIS Content"
 
-# 0.34 (2026-03-30)
+## 0.35 (2026-04-01)
+- Default terms can now be removed from WPAA
+- Default terms are only registered on activation
+- Changed remove_when_empty on the fields in post 'participants' and 'fetcher' to false
+- Changed name of taxonomy support-status => support-category
+
+## 0.34 (2026-03-30)
 - First version live! Replacing plugin "ACF".
 - Renamed 'nullable' to 'remove_when_empty' for clarity
 - Changed some settings so it aligns with requirements / old ACF settings

--- a/functions/loopis_custom_fields.php
+++ b/functions/loopis_custom_fields.php
@@ -20,7 +20,7 @@ function loopis_enqueue_datetime_picker( $hook ) {
     }
 
     // Optional: only on certain CPTs
-    // This loads the scripts only for editing the specified post types: post, FAQ, forum and support
+    // This loads the scripts only for editing the specified post types: post and support
     $screen = get_current_screen();
     if ( ! in_array( $screen->post_type, [ 'post', 'support' ], true ) ) {
         return;
@@ -73,7 +73,7 @@ function loopis_get_field_groups() {
                 'title' => [
                     'label' => 'Title',
                     'type'  => 'text',
-                    'remove_when_empty' => true,
+                    'remove_when_empty' => true, // true will remove meta_key + meta_value when empty
                 ],
                 'link' => [
                     'label' => 'Link',
@@ -83,7 +83,7 @@ function loopis_get_field_groups() {
                 'status' => [
                     'label' => 'Status',
                     'type'  => 'taxonomy',
-                    'taxonomy' => 'support-status', // needed for the taxonomy field
+                    'taxonomy' => 'support-category', // needed for the taxonomy field
                     'remove_when_empty' => false, // false, will never be empty because of the default value
                     'default' => 198, // default status: pågående, remove 'default' => 198, to remove default value
                 ],
@@ -129,13 +129,13 @@ function loopis_get_field_groups() {
                     'label' => 'Participants',
                     'type'  => 'user_ajax',
                     'multiple' => true, // needed for multiple users
-                    'remove_when_empty' => false, // will keep the meta_key with empty value ('')
+                    'remove_when_empty' => true,
                 ],
                 'fetcher' => [
                     'label' => 'Fetcher',
                     'type'  => 'user_ajax',
                     'multiple' => false, // needed for single user, difference from ACF: this value can be empty, in ACF it can't be cleared from WPAA/Gutenberg
-                    'remove_when_empty' => false, // will keep the meta_key with empty value ('')
+                    'remove_when_empty' => true,
                 ],
                 'queue' => [
                     'label' => 'Queue',

--- a/functions/loopis_default_terms.php
+++ b/functions/loopis_default_terms.php
@@ -41,15 +41,7 @@ function loopis_add_default_terms() {
             [
                 'name' => 'Om föreningen',
                 'slug' => 'organisation',
-            ],
-            [
-                'name' => 'Support',
-                'slug' => 'support',
-            ],
-            [
-                'name' => 'Kontakt',
-                'slug' => 'contact',
-            ],            
+            ],         
         ],
 
         // Forum categories
@@ -83,7 +75,7 @@ function loopis_add_default_terms() {
 
         // Support categories
         
-        'support-status' => [
+        'support-category' => [
             [
                 'name' => '⚠ Pågående',
                 'slug' => 'active',
@@ -119,10 +111,7 @@ function loopis_add_default_terms() {
     }
 }
 
-// Add the function in init and on register activation hook
-
-add_action('init', 'loopis_add_default_terms');
-
-register_activation_hook( __FILE__, 'loopis_add_default_terms' );
+// Uncomment below line if terms should be recreated if they are removed in WP admin (persist)
+//add_action('init', 'loopis_add_default_terms');
 
 ?>

--- a/functions/loopis_register_cpt.php
+++ b/functions/loopis_register_cpt.php
@@ -33,7 +33,7 @@ function register_cpts() {
         'show_ui'               => true,
         'show_in_menu'          => false,
         'menu_icon'             => 'dashicons-sticky',
-        'hierarchical'          => true,
+        'hierarchical'          => false, // for sorting date/desc, treat as post
         'has_archive'           => 'faq',
         'query_var'             => 'faq',
         'map_meta_cap'          => true,
@@ -76,7 +76,7 @@ function register_cpts() {
         'show_ui'               => true,
         'show_in_menu'          => false,
         'menu_icon'             => 'dashicons-admin-comments',
-        'hierarchical'          => true,
+        'hierarchical'          => false, // for sorting date/desc, treat as post
         'has_archive'           => false,
         'query_var'             => 'forum',
         'map_meta_cap'          => true,
@@ -118,7 +118,7 @@ function register_cpts() {
         'show_ui'               => true,
         'show_in_menu'          => false,
         'menu_icon'             => 'dashicons-sos',
-        'hierarchical'          => true,
+        'hierarchical'          => false, // for sorting date/desc, treat as post
         'has_archive'           => false,
         'query_var'             => 'support',
         'map_meta_cap'          => true,

--- a/functions/loopis_register_tax.php
+++ b/functions/loopis_register_tax.php
@@ -21,10 +21,10 @@ function register_taxonomies() {
             'name' => 'FAQ-tags',
             'hierarchical' => false, // false for "tags" (not hierarchical taxonomy type)
             'show_ui'           => true,
-            'show_in_nav_menus' => true,
-            'show_tagcloud'     => true,
+            'show_in_nav_menus' => false,
             'show_admin_column' => true,
-            'public'            => true,
+            'show_tagcloud'     => false,
+            'public'            => false,
         ],
 
         'forum-category' => [
@@ -32,19 +32,23 @@ function register_taxonomies() {
             'slug' => 'forum-category',
             'name' => 'Forum-categories',
             'hierarchical' => true, // hierarchical categories 
+            'show_ui'           => true,
+            'show_in_nav_menus' => false,
             'show_admin_column' => true,
-            'show_tagcloud'     => true,
-            'public'            => true,
+            'show_tagcloud'     => false,
+            'public'            => false,
         ],
         
-        'support-status' => [
+        'support-category' => [ 
             'post_type' => 'support',
-            'slug' => 'support-status',
-            'name' => 'Support-status',
+            'slug' => 'support-category',
+            'name' => 'Support-categories',
             'hierarchical' => true, // hierarchical categories
-            'show_tagcloud'     => true,
+            'show_ui'           => true,
+            'show_in_nav_menus' => false,
             'show_admin_column' => true,
-            'public'            => true,
+            'show_tagcloud'     => false,
+            'public'            => false,
         ],
 
         // Add more taxonomies here
@@ -56,8 +60,12 @@ function register_taxonomies() {
             'labels' => [
                 'name' => $tax['name'],
             ],
-            'hierarchical' => $tax['hierarchical'],
-            'rewrite' => [ 'slug' => $tax['slug'], 'with_front' => false ],
+            'hierarchical'      => $tax['hierarchical'],
+            'rewrite'           => false,
+            'query_var'         => false,
+            'publicly_queryable' => false,
+            'show_ui'           => $tax['show_ui'],
+            'show_in_nav_menus' => $tax['show_in_nav_menus'],
             'show_in_rest'      => true,
             'show_admin_column' => $tax['show_admin_column'],
             'show_tagcloud'     => $tax['show_tagcloud'],

--- a/loopis-content.php
+++ b/loopis-content.php
@@ -3,7 +3,7 @@
 * Plugin Name:  LOOPIS Content
 * Plugin URI:   https://github.com/LOOPIS-app/loopis-content
 * Description:  Plugin for configuring and creating the post content of LOOPIS.app
-* Version:      0.34
+* Version:      0.35
 * Author:       The Develoopers
 * Author URI:   https://loopis.org
 * License:      GPL-3.0-or-later
@@ -29,8 +29,11 @@ if (!defined('ABSPATH')) {
 // Load taxonomies
 require_once plugin_dir_path( __FILE__ ) . '/functions/loopis_register_tax.php';
 
-// Load default terms in taxonomies
+// Load default terms in taxonomies function
 require_once plugin_dir_path( __FILE__ ) . '/functions/loopis_default_terms.php';
+
+// Add default terms on activation
+register_activation_hook( __FILE__, 'loopis_add_default_terms' );
 
 // Load CPTs
 require_once plugin_dir_path( __FILE__ ) . '/functions/loopis_register_cpt.php';


### PR DESCRIPTION
Default terms can now be removed from WPAA.
Default terms are only registered on activation.
Changed remove_when_empty on the fields in post 'participants' and 'fetcher' to false.
Changed name of taxonomy support-status => support-category.